### PR TITLE
fix: eth_call indexing issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,9 @@ services:
       # Change next line if you want to connect to a different JSON-RPC endpoint
       ethereum: 'fuse:https://explorer-node.fuse.io'
       GRAPH_LOG: info
+      GRAPH_ALLOW_NON_DETERMINISTIC_IPFS: 'true' 
   ipfs:
-    image: ipfs/go-ipfs:v0.4.23
+    image: ipfs/kubo:v0.17.0
     ports:
       - '5001:5001'
     volumes:

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,7 +22,6 @@ type Collectible @entity {
   name: String
   description: String
   imageURL: String
-
 }
 
 type Collection @entity {
@@ -31,4 +30,14 @@ type Collection @entity {
   collectionSymbol: String
   collectionAddress: Bytes!
   collectibles: [Collectible!] @derivedFrom(field: "collection")
+}
+
+type IndexedBlock @entity {
+  id: ID!
+  collectibles: [CollectiblesOfIndexedBlock!] @derivedFrom(field: "block")
+}
+
+type CollectiblesOfIndexedBlock @entity {
+  id: ID!
+  block: IndexedBlock!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,6 +34,7 @@ type Collection @entity {
 
 type IndexedBlock @entity {
   id: ID!
+  number: BigInt!
   collectibles: [CollectiblesOfIndexedBlock!] @derivedFrom(field: "block")
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,8 @@ export const ADDRESS_ZERO = Address.fromString(
   "0x0000000000000000000000000000000000000000"
 );
 
+export let INDEXED_BLOCK_ID= "indexed-block-id"
+
 export let IPFS_SCHEME = "ipfs://";
 
 export let HTTP_SCHEME = "https://";

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.4
+specVersion: 0.0.8
 features:
   - ipfsOnEthereumContracts
 description: NFT subgraph for fuse
@@ -11,7 +11,7 @@ dataSources:
     network: fuse
     source:
       abi: Erc721
-      startBlock: 0
+      startBlock: 9122519
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -43,4 +43,6 @@ templates:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
+      blockHandlers:
+        - handler: handleBlock
       file: ./src/mapping.ts


### PR DESCRIPTION
Resolved an indexing issue, specifically an error when calling eth_call tokenURI, by adding blockHandlers and a handleBlock function that is invoked at the end of block indexing. Added two entities for storing transaction information in IndexedBlock and CollectiblesOfIndexedBlock. Updated the specVersion in the subgraph.yaml file from 0.0.4 to 0.0.8.